### PR TITLE
feat: add interactive task manager demo page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import Link from 'next/link'
 
 function DarkModeToggle() {
   const [dark, setDark] = useState(false)
@@ -30,11 +31,19 @@ function DarkModeToggle() {
   )
 }
 
-const features = [
+interface Feature {
+  title: string
+  description: string
+  icon: string
+  href?: string
+}
+
+const features: Feature[] = [
   {
     title: 'Quick Add Tasks',
     description: 'Create and manage tasks with a simple, intuitive interface. No signup required.',
     icon: '⚡',
+    href: '/tasks',
   },
   {
     title: 'Organize Notes',
@@ -72,28 +81,48 @@ export default function Home() {
           A minimal sandbox app for testing the feedback-chat pipeline end-to-end.
           Try the feedback widget in the bottom-right corner.
         </p>
-        <a
-          href="#features"
-          className="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-lg transition-colors shadow-lg shadow-blue-600/25"
-        >
-          Explore Features
-        </a>
+        <div className="flex gap-4">
+          <Link
+            href="/tasks"
+            className="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-lg transition-colors shadow-lg shadow-blue-600/25"
+          >
+            Try Task Manager
+          </Link>
+          <a
+            href="#features"
+            className="px-8 py-3 border border-gray-300 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-400 text-gray-700 dark:text-gray-300 rounded-lg font-medium text-lg transition-colors"
+          >
+            Explore Features
+          </a>
+        </div>
       </section>
 
       {/* Features */}
       <section id="features" className="px-6 py-20 max-w-6xl mx-auto">
         <h2 className="text-3xl font-bold text-center mb-12">What you can do</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="p-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 hover:border-blue-400 dark:hover:border-blue-500 transition-colors"
-            >
-              <div className="text-3xl mb-4">{feature.icon}</div>
-              <h3 className="text-lg font-semibold mb-2">{feature.title}</h3>
-              <p className="text-gray-600 dark:text-gray-400 text-sm">{feature.description}</p>
-            </div>
-          ))}
+          {features.map((feature) => {
+            const card = (
+              <div
+                key={feature.title}
+                className={`p-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 hover:border-blue-400 dark:hover:border-blue-500 transition-colors ${feature.href ? 'cursor-pointer' : ''}`}
+              >
+                <div className="text-3xl mb-4">{feature.icon}</div>
+                <h3 className="text-lg font-semibold mb-2">{feature.title}</h3>
+                <p className="text-gray-600 dark:text-gray-400 text-sm">{feature.description}</p>
+                {feature.href && (
+                  <span className="inline-block mt-3 text-sm text-blue-600 dark:text-blue-400 font-medium">
+                    Try it &rarr;
+                  </span>
+                )}
+              </div>
+            )
+            return feature.href ? (
+              <Link key={feature.title} href={feature.href}>{card}</Link>
+            ) : (
+              card
+            )
+          })}
         </div>
       </section>
 

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+
+interface Task {
+  id: string
+  text: string
+  completed: boolean
+}
+
+const STORAGE_KEY = 'demo_tasks'
+
+const DEFAULT_TASKS: Task[] = [
+  { id: '1', text: 'Try the feedback widget (bottom-right corner)', completed: false },
+  { id: '2', text: 'Toggle dark mode in the navbar', completed: false },
+  { id: '3', text: 'Add your own tasks below', completed: false },
+]
+
+function loadTasks(): Task[] {
+  if (typeof window === 'undefined') return DEFAULT_TASKS
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored) {
+    try { return JSON.parse(stored) } catch { /* fall through */ }
+  }
+  return DEFAULT_TASKS
+}
+
+export default function TasksPage() {
+  const [tasks, setTasks] = useState<Task[]>(DEFAULT_TASKS)
+  const [input, setInput] = useState('')
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setTasks(loadTasks())
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (mounted) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks))
+    }
+  }, [tasks, mounted])
+
+  function addTask() {
+    const text = input.trim()
+    if (!text) return
+    setTasks([...tasks, { id: Date.now().toString(), text, completed: false }])
+    setInput('')
+  }
+
+  function toggleTask(id: string) {
+    setTasks(tasks.map(t => t.id === id ? { ...t, completed: !t.completed } : t))
+  }
+
+  function deleteTask(id: string) {
+    setTasks(tasks.filter(t => t.id !== id))
+  }
+
+  const completed = tasks.filter(t => t.completed).length
+  const total = tasks.length
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-[#0f172a] text-gray-900 dark:text-gray-100 transition-colors">
+      {/* Header */}
+      <nav className="flex items-center justify-between px-6 py-4 max-w-3xl mx-auto">
+        <Link href="/" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+          ← Back to home
+        </Link>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {completed}/{total} completed
+        </span>
+      </nav>
+
+      <main className="px-6 py-8 max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-2">Task Manager</h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-8">
+          A simple demo — all data stored in localStorage. Try the feedback widget to suggest improvements!
+        </p>
+
+        {/* Add task form */}
+        <form
+          onSubmit={(e) => { e.preventDefault(); addTask() }}
+          className="flex gap-3 mb-8"
+        >
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Add a new task..."
+            className="flex-1 px-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 placeholder-gray-400 dark:placeholder-gray-500"
+          />
+          <button
+            type="submit"
+            className="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors shadow-sm"
+          >
+            Add
+          </button>
+        </form>
+
+        {/* Task list */}
+        <div className="space-y-2">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 group"
+            >
+              <button
+                onClick={() => toggleTask(task.id)}
+                className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
+                  task.completed
+                    ? 'bg-blue-600 border-blue-600 text-white'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-blue-400'
+                }`}
+              >
+                {task.completed && (
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </button>
+              <span className={`flex-1 ${task.completed ? 'line-through text-gray-400 dark:text-gray-500' : ''}`}>
+                {task.text}
+              </span>
+              <button
+                onClick={() => deleteTask(task.id)}
+                className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all text-sm"
+              >
+                Delete
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {tasks.length === 0 && (
+          <p className="text-center text-gray-400 dark:text-gray-500 py-12">
+            No tasks yet. Add one above!
+          </p>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `/tasks` page with add, complete, delete functionality and localStorage persistence
- Default placeholder tasks guide new users
- Completion counter in header
- Full dark mode support matching landing page
- Landing page hero CTA now links to `/tasks`
- "Quick Add Tasks" feature card is clickable

Closes #53

## Test plan
- [ ] Navigate to /tasks and verify task CRUD works
- [ ] Refresh page and verify tasks persist via localStorage
- [ ] Toggle dark mode and verify /tasks page matches
- [ ] Click "Try Task Manager" CTA on landing page
- [ ] Click "Quick Add Tasks" feature card

Generated with [Claude Code](https://claude.com/claude-code)